### PR TITLE
Update hbs to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "debug": "~2.1.1",
     "express": "~4.11.1",
     "express-session": "^1.10.1",
-    "hbs": "~2.8.0",
+    "hbs": "~4.0.0",
     "morgan": "~1.5.1",
     "passport": "^0.2.1",
     "passport-saml": "^0.15.0",


### PR DESCRIPTION
The old version of hbs required foreachasync 2.2, which doesn't seem to be available any longer.  So, I just kept incrementing the hbs version until things worked.

@karlmcguinness-okta I forked your project, because I didn't have perms to create a branch.  Of course, I don't want to have a fork.