### PR TITLE
Fix cert.match error and add support for EntitiesDescriptor in IdP metadata

### DIFF
--- a/lib/idp-metadata.js
+++ b/lib/idp-metadata.js
@@ -61,6 +61,13 @@ function fetch(url) {
           return reject(err);
         }
 
+        if (docEl.EntitiesDescriptor) {
+          docEl = docEl.EntitiesDescriptor;
+          if (Array.isArray(docEl.EntityDescriptor)) {
+            docEl.EntityDescriptor = docEl.EntityDescriptor[0];
+          }
+        }
+
         if (docEl.EntityDescriptor) {
           metadata.issuer = docEl.EntityDescriptor.$.entityID
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -169,7 +169,7 @@ function processArgs(options) {
         required: false,
         string: true,
         coerce: (value) => {
-          return certToPEM(makeCertFileCoercer('certificate', 'IdP Public Key Signing Certificate (PEM)', KEY_CERT_HELP_TEXT));
+          return certToPEM(makeCertFileCoercer('certificate', 'IdP Public Key Signing Certificate (PEM)', KEY_CERT_HELP_TEXT)(value));
         }
       },
       idpThumbprint: {


### PR DESCRIPTION
This pull request addresses the following issues:

* Fixes "cert.match is not a function" error when using local file path as value for `--idpCert` argument
* Cannot parse IdP metadata when root node is an `EntitiesDescriptor` element. (This is probably an edge case, but apparently this is valid DOM per SAML 2.0 spec for metadata.)

I encountered the latter issue while using Keycloak as IdP. The metadata exported by Keycloak's descriptor endpoint wraps the `EntityDescriptor` node in a root `EntitiesDescriptor` element.