### PR TITLE
Handle missing nameIdAttributes

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -195,8 +195,8 @@ module.exports.create = (config) => {
       return done(null, {
         issuer: profile.issuer,
         subject: {
-          name: profile.nameIdAttributes.value,
-          format: profile.nameIdAttributes.Format
+          name: (profile.nameIdAttributes || {}).value,
+          format: (profile.nameIdAttributes || {}).Format
         },
         authnContext: {
           sessionIndex: profile.sessionIndex,


### PR DESCRIPTION
Gracefully handle the case when the profile from the IDP does not contain nameIdAttributes.