### PR TITLE
Use X-Forwarded-Proto header if present

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -31,7 +31,7 @@ function getPath(path) {
 
 function getReqUrl(req, path) {
   if (req) {
-    return req.protocol + '://' + (req.get('x-forwarded-host') || req.get('host')) + getPath(path || req.originalUrl);
+    return (req.get('x-forwarded-proto') || req.protocol) + '://' + (req.get('x-forwarded-host') || req.get('host')) + getPath(path || req.originalUrl);
   }
 };
 


### PR DESCRIPTION
When calculating the request url, use the X-Forwarded-Proto header if it's present.

This handles situations in which SSL is offloaded by an upstream proxy or LB.